### PR TITLE
Reuse the same connection for requests (fixes #5)

### DIFF
--- a/example.go
+++ b/example.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/ccding/go-stun/stun"
 )
 
@@ -27,26 +28,7 @@ func main() {
 		fmt.Println(err)
 	}
 
-	switch nat {
-	case stun.NAT_ERROR:
-		fmt.Println("Test failed")
-	case stun.NAT_UNKNOWN:
-		fmt.Println("Unexpected response from the STUN server")
-	case stun.NAT_BLOCKED:
-		fmt.Println("UDP is blocked")
-	case stun.NAT_FULL:
-		fmt.Println("Full cone NAT")
-	case stun.NAT_SYMETRIC:
-		fmt.Println("Symetric NAT")
-	case stun.NAT_RESTRICTED:
-		fmt.Println("Restricted NAT")
-	case stun.NAT_PORT_RESTRICTED:
-		fmt.Println("Port restricted NAT")
-	case stun.NAT_NONE:
-		fmt.Println("Not behind a NAT")
-	case stun.NAT_SYMETRIC_UDP_FIREWALL:
-		fmt.Println("Symetric UDP firewall")
-	}
+	fmt.Println(nat)
 
 	if host != nil {
 		fmt.Println(host.Family())

--- a/stun/client.go
+++ b/stun/client.go
@@ -25,10 +25,18 @@ import (
 type Client struct {
 	serverAddr   string
 	softwareName string
+	conn         net.Conn
 }
 
 func NewClient() *Client {
 	c := new(Client)
+	c.SetSoftwareName(DefaultSoftwareName)
+	return c
+}
+
+func NewClientWithConnection(conn net.Conn) *Client {
+	c := new(Client)
+	c.conn = conn
 	c.SetSoftwareName(DefaultSoftwareName)
 	return c
 }
@@ -66,5 +74,13 @@ func (c *Client) Discover() (NATType, *Host, error) {
 			return NAT_ERROR, nil, err
 		}
 	}
-	return discover(c.serverAddr)
+	if c.conn == nil {
+		conn, err := net.Dial("udp", c.serverAddr)
+		if err != nil {
+			return NAT_ERROR, nil, err
+		}
+		c.conn = conn
+		defer conn.Close()
+	}
+	return discover(c.conn)
 }

--- a/stun/const.go
+++ b/stun/const.go
@@ -41,6 +41,30 @@ const (
 	NAT_SYMETRIC_UDP_FIREWALL
 )
 
+func (nat NATType) String() string {
+	switch nat {
+	case NAT_ERROR:
+		return "Test failed"
+	case NAT_UNKNOWN:
+		return "Unexpected response from the STUN server"
+	case NAT_BLOCKED:
+		return "UDP is blocked"
+	case NAT_FULL:
+		return "Full cone NAT"
+	case NAT_SYMETRIC:
+		return "Symetric NAT"
+	case NAT_RESTRICTED:
+		return "Restricted NAT"
+	case NAT_PORT_RESTRICTED:
+		return "Port restricted NAT"
+	case NAT_NONE:
+		return "Not behind a NAT"
+	case NAT_SYMETRIC_UDP_FIREWALL:
+		return "Symetric UDP firewall"
+	}
+	return "Unknown"
+}
+
 const (
 	error_TRY_ALTERNATE                  = 300
 	error_BAD_REQUEST                    = 400


### PR DESCRIPTION
Verified that this fixes my issue where my NAT was identified as Symetric NAT, though in reality it was a Full Cone (verified by pystun and [C# client](http://www.codeproject.com/Articles/18492/STUN-Client))

It seems that using `net.Dial` multiple times uses a different local port every time, which as a result causes Stun servers to ignore 2nd request/test.

Also makes it easier to print the type, and allows passing our own connection.