### PR TITLE
s/Symetric/Symmetric/

### DIFF
--- a/stun/const.go
+++ b/stun/const.go
@@ -37,10 +37,10 @@ const (
 	NATNone
 	NATBlocked
 	NATFull
-	NATSymetric
+	NATSymmetric
 	NATRestricted
 	NATPortRestricted
-	NATSymetricUDPFirewall
+	NATSymmetricUDPFirewall
 )
 
 var natStr map[NATType]string
@@ -51,11 +51,11 @@ func init() {
 		NATUnknown:             "Unexpected response from the STUN server",
 		NATBlocked:             "UDP is blocked",
 		NATFull:                "Full cone NAT",
-		NATSymetric:            "Symetric NAT",
+		NATSymmetric:            "Symmetric NAT",
 		NATRestricted:          "Restricted NAT",
 		NATPortRestricted:      "Port restricted NAT",
 		NATNone:                "Not behind a NAT",
-		NATSymetricUDPFirewall: "Symetric UDP firewall",
+		NATSymmetricUDPFirewall: "Symmetric UDP firewall",
 	}
 }
 

--- a/stun/discover.go
+++ b/stun/discover.go
@@ -114,7 +114,7 @@ func (c *Client) discover(conn net.PacketConn, addr *net.UDPAddr) (NATType, *Hos
 	}
 	if identical {
 		if resp == nil {
-			return NATSymetricUDPFirewall, mappedAddr, nil
+			return NATSymmetricUDPFirewall, mappedAddr, nil
 		}
 		return NATNone, mappedAddr, nil
 	}
@@ -161,5 +161,5 @@ func (c *Client) discover(conn net.PacketConn, addr *net.UDPAddr) (NATType, *Hos
 		}
 		return NATRestricted, mappedAddr, nil
 	}
-	return NATSymetric, mappedAddr, nil
+	return NATSymmetric, mappedAddr, nil
 }


### PR DESCRIPTION
Yes, this is just a spelling correction. However it's a misspelling that leaks into both the API and log messages (via the String()) message.

As such it might be a breaking change for some.