### PR TITLE
Safely assert error type

### DIFF
--- a/stun/net.go
+++ b/stun/net.go
@@ -78,7 +78,7 @@ func (c *Client) send(pkt *packet, conn net.PacketConn, addr net.Addr) (*respons
 			// Read from the port.
 			length, raddr, err := conn.ReadFrom(packetBytes)
 			if err != nil {
-				if err.(net.Error).Timeout() {
+				if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 					break
 				}
 				return nil, err


### PR DESCRIPTION
net.PacketConn is an interface in my case provided by my own library that wraps another 3 libraries, so I can't guarantee that I'll always get a net.Error.