### PR TITLE
fix and check bounds reading packets

### DIFF
--- a/stun/packet_test.go
+++ b/stun/packet_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 func TestNewPacketFromBytes(t *testing.T) {
-	b := make([]byte, 23)
+	b := make([]byte, 19)
 	_, err := newPacketFromBytes(b)
 	if err == nil {
 		t.Errorf("newPacketFromBytes error")
 	}
-	b = make([]byte, 24)
+	b = make([]byte, 20)
 	_, err = newPacketFromBytes(b)
 	if err != nil {
 		t.Errorf("newPacketFromBytes error")
@@ -53,7 +53,7 @@ func TestPacketAll(t *testing.T) {
 	if pkt.types != 0 {
 		t.Errorf("newPacketFromBytes error")
 	}
-	if pkt.length < 24 {
+	if pkt.length < 20 {
 		t.Errorf("newPacketFromBytes error")
 	}
 }


### PR DESCRIPTION
A lot of "slice bounds out of range" panics are occurring at https://github.com/ccding/go-stun/blob/master/stun/packet.go#L58

https://sentry.syncthing.net/share/issue/6d20d6707bfd4880a1ed8d1205f94d1d/
https://sentry.syncthing.net/share/issue/0c228b7490c84d82a7c6357bde37028c/

Two example bounds: [24:3] and [24:1]. Looks like the decoded `uint16 length` is overflowing when adding `pos+4`.

Looking at the code there's a few issues:

 - The condition on the iteration is wrong: The ranges later on can exceed the packet length.  
 - The header length is 20 bytes, not sure where the 24 in code comes from?
 - Converting the length to `uint16` isn't ok, it might be max(uint16)+20 according to spec. I don't understand the need to do the iteration with `uint16`, but I kept it just in case - removing the header from the slice before taking the length.
 - The overflow: Added a condition.