### PR TITLE
Refactor STUN client for safety, performance, and maintainability

### DIFF
--- a/stun/attribute.go
+++ b/stun/attribute.go
@@ -16,6 +16,7 @@ package stun
 
 import (
 	"encoding/binary"
+	"errors"
 	"hash/crc32"
 	"net"
 )
@@ -65,19 +66,43 @@ func newChangeReqAttribute(changeIP bool, changePort bool) *attribute {
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //
 //             Figure 6: Format of XOR-MAPPED-ADDRESS Attribute
-func (v *attribute) xorAddr(transID []byte) *Host {
-	xorIP := make([]byte, 16)
-	for i := 0; i < len(v.value)-4; i++ {
-		xorIP[i] = v.value[i+4] ^ transID[i]
+func (v *attribute) xorAddr(transID []byte) (*Host, error) {
+	if len(v.value) < 4 {
+		return nil, errors.New("attribute value too short")
 	}
 	family := uint16(v.value[1])
 	port := binary.BigEndian.Uint16(v.value[2:4])
-	// Truncate if IPv4, otherwise net.IP sometimes renders it as an IPv6 address.
+	
+	xorIP := make([]byte, 16)
+	limit := len(v.value) - 4
+	if limit > 16 {
+		limit = 16
+	}
+	if len(transID) < limit {
+		return nil, errors.New("transaction ID too short")
+	}
+	for i := 0; i < limit; i++ {
+		xorIP[i] = v.value[i+4] ^ transID[i]
+	}
+	
 	if family == attributeFamilyIPv4 {
+		if len(v.value) < 8 {
+			return nil, errors.New("IPv4 attribute length mismatch")
+		}
 		xorIP = xorIP[:4]
+	} else if family == attributeFamilyIPV6 {
+		if len(v.value) < 20 {
+			return nil, errors.New("IPv6 attribute length mismatch")
+		}
+	} else {
+		return nil, errors.New("unknown address family")
+	}
+	
+	if len(transID) < 2 {
+		return nil, errors.New("transaction ID too short for port XOR")
 	}
 	x := binary.BigEndian.Uint16(transID[:2])
-	return &Host{family, net.IP(xorIP).String(), port ^ x}
+	return &Host{family, net.IP(xorIP).String(), port ^ x}, nil
 }
 
 //       0                   1                   2                   3
@@ -91,14 +116,27 @@ func (v *attribute) xorAddr(transID []byte) *Host {
 //      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //
 //               Figure 5: Format of MAPPED-ADDRESS Attribute
-func (v *attribute) rawAddr() *Host {
-	host := new(Host)
-	host.family = uint16(v.value[1])
-	host.port = binary.BigEndian.Uint16(v.value[2:4])
-	// Truncate if IPv4, otherwise net.IP sometimes renders it as an IPv6 address.
-	if host.family == attributeFamilyIPv4 {
-		v.value = v.value[:8]
+func (v *attribute) rawAddr() (*Host, error) {
+	if len(v.value) < 4 {
+		return nil, errors.New("attribute value too short")
 	}
-	host.ip = net.IP(v.value[4:]).String()
-	return host
+	family := uint16(v.value[1])
+	port := binary.BigEndian.Uint16(v.value[2:4])
+	
+	var ip string
+	if family == attributeFamilyIPv4 {
+		if len(v.value) < 8 {
+			return nil, errors.New("IPv4 attribute length mismatch")
+		}
+		ip = net.IP(v.value[4:8]).String()
+	} else if family == attributeFamilyIPV6 {
+		if len(v.value) < 20 {
+			return nil, errors.New("IPv6 attribute length mismatch")
+		}
+		ip = net.IP(v.value[4:20]).String()
+	} else {
+		return nil, errors.New("unknown address family")
+	}
+	
+	return &Host{family, ip, port}, nil
 }

--- a/stun/attribute_safety_test.go
+++ b/stun/attribute_safety_test.go
@@ -1,0 +1,127 @@
+// Copyright 2016 Cong Ding
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"testing"
+)
+
+func TestAttributeSafetyRawAddr(t *testing.T) {
+	// Test case 1: attribute too short (< 4 bytes)
+	att1 := &attribute{
+		types:  attributeMappedAddress,
+		length: 2,
+		value:  []byte{0x00, 0x01},
+	}
+	_, err := att1.rawAddr()
+	if err == nil {
+		t.Error("expected error for attribute value too short (< 4 bytes)")
+	}
+
+	// Test case 2: IPv4 family but too short (< 8 bytes)
+	att2 := &attribute{
+		types:  attributeMappedAddress,
+		length: 6,
+		value:  []byte{0x00, 0x01, 0x12, 0x34, 0x01, 0x02},
+	}
+	_, err = att2.rawAddr()
+	if err == nil {
+		t.Error("expected error for IPv4 attribute length mismatch (< 8 bytes)")
+	}
+
+	// Test case 3: IPv6 family but too short (< 20 bytes)
+	att3 := &attribute{
+		types:  attributeMappedAddress,
+		length: 12,
+		value:  []byte{0x00, 0x02, 0x12, 0x34, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+	}
+	_, err = att3.rawAddr()
+	if err == nil {
+		t.Error("expected error for IPv6 attribute length mismatch (< 20 bytes)")
+	}
+
+	// Test case 4: unknown family type
+	att4 := &attribute{
+		types:  attributeMappedAddress,
+		length: 8,
+		value:  []byte{0x00, 0x03, 0x12, 0x34, 0x01, 0x02, 0x03, 0x04},
+	}
+	_, err = att4.rawAddr()
+	if err == nil {
+		t.Error("expected error for unknown address family")
+	}
+
+	// Test case 5: valid IPv4
+	att5 := &attribute{
+		types:  attributeMappedAddress,
+		length: 8,
+		value:  []byte{0x00, 0x01, 0x12, 0x34, 127, 0, 0, 1},
+	}
+	host, err := att5.rawAddr()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if host.ip != "127.0.0.1" || host.port != 0x1234 {
+		t.Errorf("invalid host: %v", host)
+	}
+}
+
+func TestAttributeSafetyXorAddr(t *testing.T) {
+	transID := make([]byte, 16)
+
+	// Test case 1: attribute too short (< 4 bytes)
+	att1 := &attribute{
+		types:  attributeXorMappedAddress,
+		length: 2,
+		value:  []byte{0x00, 0x01},
+	}
+	_, err := att1.xorAddr(transID)
+	if err == nil {
+		t.Error("expected error for attribute value too short (< 4 bytes)")
+	}
+
+	// Test case 2: IPv4 family but too short (< 8 bytes)
+	att2 := &attribute{
+		types:  attributeXorMappedAddress,
+		length: 6,
+		value:  []byte{0x00, 0x01, 0x12, 0x34, 0x01, 0x02},
+	}
+	_, err = att2.xorAddr(transID)
+	if err == nil {
+		t.Error("expected error for IPv4 attribute length mismatch (< 8 bytes)")
+	}
+
+	// Test case 3: IPv6 family but too short (< 20 bytes)
+	att3 := &attribute{
+		types:  attributeXorMappedAddress,
+		length: 12,
+		value:  []byte{0x00, 0x02, 0x12, 0x34, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+	}
+	_, err = att3.xorAddr(transID)
+	if err == nil {
+		t.Error("expected error for IPv6 attribute length mismatch (< 20 bytes)")
+	}
+
+	// Test case 4: transaction ID too short
+	att4 := &attribute{
+		types:  attributeXorMappedAddress,
+		length: 8,
+		value:  []byte{0x00, 0x01, 0x12, 0x34, 0x01, 0x02, 0x03, 0x04},
+	}
+	_, err = att4.xorAddr(transID[:2]) // transID too short
+	if err == nil {
+		t.Error("expected error for transaction ID too short")
+	}
+}

--- a/stun/attribute_safety_test.go
+++ b/stun/attribute_safety_test.go
@@ -1,17 +1,3 @@
-// Copyright 2016 Cong Ding
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package stun
 
 import (

--- a/stun/client.go
+++ b/stun/client.go
@@ -16,7 +16,6 @@ package stun
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"strconv"
 )
@@ -89,6 +88,25 @@ func (c *Client) SetSoftwareName(name string) {
 	c.softwareName = name
 }
 
+// acquireConn establishes a UDP socket connection using local IP and port settings,
+// or returns the pre-configured connection if available.
+func (c *Client) acquireConn() (net.PacketConn, error) {
+	if c.conn != nil {
+		return c.conn, nil
+	}
+	var laddr *net.UDPAddr
+	var err error
+	if c.localPort != 0 || c.localIP != "" {
+		address := net.JoinHostPort(c.localIP, strconv.Itoa(c.localPort))
+		laddr, err = net.ResolveUDPAddr("udp", address)
+		if err != nil {
+			return nil, err
+		}
+		c.logger.Debugln("Local listen address: " + address)
+	}
+	return net.ListenUDP("udp", laddr)
+}
+
 // Discover contacts the STUN server and gets the response of NAT type, host
 // for UDP punching.
 func (c *Client) Discover() (NATType, *Host, error) {
@@ -99,27 +117,11 @@ func (c *Client) Discover() (NATType, *Host, error) {
 	if err != nil {
 		return NATError, nil, err
 	}
-	// Use the connection passed to the client if it is not nil, otherwise
-	// create a connection and close it at the end.
-	conn := c.conn
-	if conn == nil {
-		var laddr *net.UDPAddr
-
-		if c.localPort != 0  || c.localIP != "" {
-			var address = fmt.Sprintf("%s:%d", c.localIP, c.localPort)
-
-			laddr, err = net.ResolveUDPAddr("udp", address)
-			if err != nil {
-				return NATError, nil, err
-			}
-
-			c.logger.Debugln("Local listen address: " + address)
-		}
-
-		conn, err = net.ListenUDP("udp", laddr)
-		if err != nil {
-			return NATError, nil, err
-		}
+	conn, err := c.acquireConn()
+	if err != nil {
+		return NATError, nil, err
+	}
+	if c.conn == nil {
 		defer conn.Close()
 	}
 	return c.discover(conn, serverUDPAddr)
@@ -134,25 +136,11 @@ func (c *Client) BehaviorTest() (*NATBehavior, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Use the connection passed to the client if it is not nil, otherwise
-	// create a connection and close it at the end.
-	conn := c.conn
-	if conn == nil {
-		var laddr *net.UDPAddr
-		if c.localPort != 0  || c.localIP != "" {
-			var address = fmt.Sprintf("%s:%d", c.localIP, c.localPort)
-
-			laddr, err = net.ResolveUDPAddr("udp", address)
-			if err != nil {
-				return nil, err
-			}
-
-			c.logger.Debugln("Local listen address: " + address)
-		}
-		conn, err = net.ListenUDP("udp", laddr)
-		if err != nil {
-			return nil, err
-		}
+	conn, err := c.acquireConn()
+	if err != nil {
+		return nil, err
+	}
+	if c.conn == nil {
 		defer conn.Close()
 	}
 	return c.behaviorTest(conn, serverUDPAddr)

--- a/stun/const.go
+++ b/stun/const.go
@@ -16,7 +16,7 @@ package stun
 
 // Default server address and client name.
 const (
-	DefaultServerAddr   = "stun.ekiga.net:3478"
+	DefaultServerAddr   = "stun.sipgate.net:10000"
 	DefaultSoftwareName = "StunClient"
 )
 

--- a/stun/discover_mock_test.go
+++ b/stun/discover_mock_test.go
@@ -1,17 +1,3 @@
-// Copyright 2016 Cong Ding
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package stun
 
 import (

--- a/stun/discover_mock_test.go
+++ b/stun/discover_mock_test.go
@@ -1,0 +1,160 @@
+// Copyright 2016 Cong Ding
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+func mockResponse(t *testing.T, transID []byte, mappedIP string, mappedPort uint16, changedIP string, changedPort uint16) []byte {
+	p, err := newPacket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.types = typeBindingResponse
+	p.transID = transID
+
+	// Add MAPPED-ADDRESS
+	mappedVal := make([]byte, 8)
+	mappedVal[1] = 0x01 // IPv4
+	binary.BigEndian.PutUint16(mappedVal[2:4], mappedPort)
+	copy(mappedVal[4:8], net.ParseIP(mappedIP).To4())
+	p.addAttribute(*newAttribute(attributeMappedAddress, mappedVal))
+
+	// Add CHANGED-ADDRESS
+	changedVal := make([]byte, 8)
+	changedVal[1] = 0x01 // IPv4
+	binary.BigEndian.PutUint16(changedVal[2:4], changedPort)
+	copy(changedVal[4:8], net.ParseIP(changedIP).To4())
+	p.addAttribute(*newAttribute(attributeChangedAddress, changedVal))
+
+	return p.bytes()
+}
+
+func TestDiscoverMockNone(t *testing.T) {
+	localAddr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:12345")
+	conn := newMockPacketConn(localAddr)
+	client := NewClientWithConnection(conn)
+	client.SetServerAddr("9.9.9.9:3478")
+
+	// Run Discover in a goroutine
+	type result struct {
+		nat NATType
+		host *Host
+		err  error
+	}
+	resChan := make(chan result, 1)
+	go func() {
+		nat, host, err := client.Discover()
+		resChan <- result{nat, host, err}
+	}()
+
+	// 1. Wait for Test I request to be written
+	select {
+	case <-conn.writeSignal:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for Test I request")
+	}
+
+	if len(conn.writeCalls) != 1 {
+		t.Fatalf("expected 1 write call, got %d", len(conn.writeCalls))
+	}
+	rec1 := conn.writeCalls[0]
+	transID1 := rec1.data[4:20]
+
+	// Send Test I response (Mapped Address matches local IP/port)
+	server1Addr, _ := net.ResolveUDPAddr("udp", "9.9.9.9:3478")
+	resp1 := mockResponse(t, transID1, "1.2.3.4", 12345, "8.8.8.8", 3479)
+	conn.readBuf <- resp1
+	conn.readAddr <- server1Addr
+
+	// 2. Wait for Test II request to be written (because mapping identical == true and we test for open internet)
+	select {
+	case <-conn.writeSignal:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for Test II request")
+	}
+
+	if len(conn.writeCalls) != 2 {
+		t.Fatalf("expected 2 write calls, got %d", len(conn.writeCalls))
+	}
+	rec2 := conn.writeCalls[1]
+	transID2 := rec2.data[4:20]
+
+	// Send Test II response
+	server2Addr, _ := net.ResolveUDPAddr("udp", "8.8.8.8:3479")
+	resp2 := mockResponse(t, transID2, "1.2.3.4", 12345, "8.8.8.8", 3479)
+	conn.readBuf <- resp2
+	conn.readAddr <- server2Addr
+
+	// Verify discover results
+	select {
+	case res := <-resChan:
+		if res.err != nil {
+			t.Fatalf("unexpected Discover error: %v", res.err)
+		}
+		if res.nat != NATNone {
+			t.Errorf("expected NAT type NATNone, got %v", res.nat)
+		}
+		if res.host == nil || res.host.IP() != "1.2.3.4" || res.host.Port() != 12345 {
+			t.Errorf("unexpected host returned: %v", res.host)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for Discover to complete")
+	}
+}
+
+func TestDiscoverMockBlocked(t *testing.T) {
+	localAddr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:12345")
+	conn := newMockPacketConn(localAddr)
+	conn.instantTimeout = true
+	// Set read deadline to fire instantly to avoid waiting 9 retransmits * timeout
+	client := NewClientWithConnection(conn)
+	client.SetServerAddr("9.9.9.9:3478")
+
+	// We let the client send packets, but we never respond.
+	// Since there are 9 retransmits, we can let it run. But wait, retransmits double timeout.
+	// To make the test run fast, let's inject a read error or timeout immediately, or just speed up the mock.
+	// Actually, mock timeout error is returned when deadline is exceeded.
+	// Since client.send loops 9 times, and each read times out after `timeout` milliseconds (which defaults to 100ms),
+	// the total timeout would be around 1.6s. That's fine for a unit test.
+	
+	type result struct {
+		nat NATType
+		host *Host
+		err  error
+	}
+	resChan := make(chan result, 1)
+	go func() {
+		nat, host, err := client.Discover()
+		resChan <- result{nat, host, err}
+	}()
+
+	// Just let it time out and verify it returns NATBlocked
+	select {
+	case res := <-resChan:
+		if res.err != nil {
+			t.Fatalf("unexpected Discover error: %v", res.err)
+		}
+		if res.nat != NATBlocked {
+			t.Errorf("expected NAT type NATBlocked, got %v", res.nat)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for Discover to complete under NATBlocked test")
+	}
+}

--- a/stun/log.go
+++ b/stun/log.go
@@ -28,7 +28,7 @@ type Logger struct {
 
 // NewLogger creates a default logger.
 func NewLogger() *Logger {
-	logger := &Logger{*log.New(os.Stdout, "", log.LstdFlags), false, false}
+	logger := &Logger{*log.New(os.Stderr, "", log.LstdFlags), false, false}
 	return logger
 }
 

--- a/stun/mock_conn_test.go
+++ b/stun/mock_conn_test.go
@@ -1,17 +1,3 @@
-// Copyright 2016 Cong Ding
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package stun
 
 import (

--- a/stun/mock_conn_test.go
+++ b/stun/mock_conn_test.go
@@ -1,0 +1,109 @@
+// Copyright 2016 Cong Ding
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stun
+
+import (
+	"net"
+	"time"
+)
+
+type mockTimeoutError struct{}
+
+func (e *mockTimeoutError) Error() string   { return "i/o timeout" }
+func (e *mockTimeoutError) Timeout() bool   { return true }
+func (e *mockTimeoutError) Temporary() bool { return true }
+
+type writeRecord struct {
+	data []byte
+	addr net.Addr
+}
+
+type mockPacketConn struct {
+	localAddr      net.Addr
+	readBuf        chan []byte
+	readAddr       chan net.Addr
+	writeCalls     []writeRecord
+	readDeadline   time.Time
+	writeSignal    chan struct{}
+	instantTimeout bool
+}
+
+func newMockPacketConn(local net.Addr) *mockPacketConn {
+	return &mockPacketConn{
+		localAddr:      local,
+		readBuf:        make(chan []byte, 100),
+		readAddr:       make(chan net.Addr, 100),
+		writeCalls:     make([]writeRecord, 0),
+		writeSignal:    make(chan struct{}, 100),
+		instantTimeout: false,
+	}
+}
+
+func (m *mockPacketConn) LocalAddr() net.Addr {
+	return m.localAddr
+}
+
+func (m *mockPacketConn) Close() error {
+	return nil
+}
+
+func (m *mockPacketConn) SetDeadline(t time.Time) error {
+	m.readDeadline = t
+	return nil
+}
+
+func (m *mockPacketConn) SetReadDeadline(t time.Time) error {
+	m.readDeadline = t
+	return nil
+}
+
+func (m *mockPacketConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockPacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	data := make([]byte, len(p))
+	copy(data, p)
+	m.writeCalls = append(m.writeCalls, writeRecord{data, addr})
+	select {
+	case m.writeSignal <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (m *mockPacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	if m.instantTimeout {
+		return 0, nil, &mockTimeoutError{}
+	}
+
+	var timeout <-chan time.Time
+	if !m.readDeadline.IsZero() {
+		dur := time.Until(m.readDeadline)
+		if dur <= 0 {
+			return 0, nil, &mockTimeoutError{}
+		}
+		timeout = time.After(dur)
+	}
+
+	select {
+	case data := <-m.readBuf:
+		copy(p, data)
+		addr = <-m.readAddr
+		return len(data), addr, nil
+	case <-timeout:
+		return 0, nil, &mockTimeoutError{}
+	}
+}

--- a/stun/net.go
+++ b/stun/net.go
@@ -95,9 +95,12 @@ func (c *Client) send(pkt *packet, conn net.PacketConn, addr net.Addr) (*respons
 				continue
 			}
 			c.logger.Info("\n" + hex.Dump(packetBytes[0:length]))
-			resp := newResponse(p, conn)
+			resp, err := newResponse(p, conn)
+			if err != nil {
+				return nil, err
+			}
 			resp.serverAddr = newHostFromStr(raddr.String())
-			return resp, err
+			return resp, nil
 		}
 	}
 	return nil, nil

--- a/stun/packet.go
+++ b/stun/packet.go
@@ -51,7 +51,10 @@ func newPacketFromBytes(packetBytes []byte) (*packet, error) {
 	pkt := new(packet)
 	pkt.types = binary.BigEndian.Uint16(packetBytes[0:2])
 	pkt.length = binary.BigEndian.Uint16(packetBytes[2:4])
-	pkt.transID = packetBytes[4:20]
+	
+	pkt.transID = make([]byte, 16)
+	copy(pkt.transID, packetBytes[4:20])
+	
 	pkt.attributes = make([]attribute, 0, 10)
 	packetBytes = packetBytes[20:]
 	for pos := uint16(0); pos+4 < uint16(len(packetBytes)); {
@@ -61,7 +64,8 @@ func newPacketFromBytes(packetBytes []byte) (*packet, error) {
 		if end < pos+4 || end > uint16(len(packetBytes)) {
 			return nil, errors.New("Received data format mismatch")
 		}
-		value := packetBytes[pos+4 : end]
+		value := make([]byte, length)
+		copy(value, packetBytes[pos+4 : end])
 		attribute := newAttribute(types, value)
 		pkt.addAttribute(*attribute)
 		pos += align(length) + 4
@@ -75,59 +79,65 @@ func (v *packet) addAttribute(a attribute) {
 }
 
 func (v *packet) bytes() []byte {
-	packetBytes := make([]byte, 4)
-	binary.BigEndian.PutUint16(packetBytes[0:2], v.types)
-	binary.BigEndian.PutUint16(packetBytes[2:4], v.length)
-	packetBytes = append(packetBytes, v.transID...)
+	size := 20 + int(v.length)
+	buf := make([]byte, size)
+	binary.BigEndian.PutUint16(buf[0:2], v.types)
+	binary.BigEndian.PutUint16(buf[2:4], v.length)
+	copy(buf[4:20], v.transID)
+	offset := 20
 	for _, a := range v.attributes {
-		buf := make([]byte, 2)
-		binary.BigEndian.PutUint16(buf, a.types)
-		packetBytes = append(packetBytes, buf...)
-		binary.BigEndian.PutUint16(buf, a.length)
-		packetBytes = append(packetBytes, buf...)
-		packetBytes = append(packetBytes, a.value...)
+		binary.BigEndian.PutUint16(buf[offset:offset+2], a.types)
+		binary.BigEndian.PutUint16(buf[offset+2:offset+4], a.length)
+		copy(buf[offset+4:offset+4+len(a.value)], a.value)
+		offset += 4 + len(a.value)
 	}
-	return packetBytes
+	return buf
 }
 
-func (v *packet) getSourceAddr() *Host {
+func (v *packet) getSourceAddr() (*Host, error) {
 	return v.getRawAddr(attributeSourceAddress)
 }
 
-func (v *packet) getMappedAddr() *Host {
+func (v *packet) getMappedAddr() (*Host, error) {
 	return v.getRawAddr(attributeMappedAddress)
 }
 
-func (v *packet) getChangedAddr() *Host {
+func (v *packet) getChangedAddr() (*Host, error) {
 	return v.getRawAddr(attributeChangedAddress)
 }
 
-func (v *packet) getOtherAddr() *Host {
+func (v *packet) getOtherAddr() (*Host, error) {
 	return v.getRawAddr(attributeOtherAddress)
 }
 
-func (v *packet) getRawAddr(attribute uint16) *Host {
+func (v *packet) getRawAddr(attribute uint16) (*Host, error) {
 	for _, a := range v.attributes {
 		if a.types == attribute {
 			return a.rawAddr()
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func (v *packet) getXorMappedAddr() *Host {
-	addr := v.getXorAddr(attributeXorMappedAddress)
-	if addr == nil {
-		addr = v.getXorAddr(attributeXorMappedAddressExp)
+func (v *packet) getXorMappedAddr() (*Host, error) {
+	addr, err := v.getXorAddr(attributeXorMappedAddress)
+	if err != nil {
+		return nil, err
 	}
-	return addr
+	if addr == nil {
+		addr, err = v.getXorAddr(attributeXorMappedAddressExp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return addr, nil
 }
 
-func (v *packet) getXorAddr(attribute uint16) *Host {
+func (v *packet) getXorAddr(attribute uint16) (*Host, error) {
 	for _, a := range v.attributes {
 		if a.types == attribute {
 			return a.xorAddr(v.transID)
 		}
 	}
-	return nil
+	return nil, nil
 }

--- a/stun/response.go
+++ b/stun/response.go
@@ -28,15 +28,21 @@ type response struct {
 	identical   bool    // if mappedAddr is in local addr list
 }
 
-func newResponse(pkt *packet, conn net.PacketConn) *response {
+func newResponse(pkt *packet, conn net.PacketConn) (*response, error) {
 	resp := &response{pkt, nil, nil, nil, nil, false}
 	if pkt == nil {
-		return resp
+		return resp, nil
 	}
 	// RFC 3489 doesn't require the server return XOR mapped address.
-	mappedAddr := pkt.getXorMappedAddr()
+	mappedAddr, err := pkt.getXorMappedAddr()
+	if err != nil {
+		return nil, err
+	}
 	if mappedAddr == nil {
-		mappedAddr = pkt.getMappedAddr()
+		mappedAddr, err = pkt.getMappedAddr()
+		if err != nil {
+			return nil, err
+		}
 	}
 	resp.mappedAddr = mappedAddr
 	// compute identical
@@ -46,19 +52,25 @@ func newResponse(pkt *packet, conn net.PacketConn) *response {
 		resp.identical = isLocalAddress(localAddrStr, mappedAddrStr)
 	}
 	// compute changedAddr
-	changedAddr := pkt.getChangedAddr()
+	changedAddr, err := pkt.getChangedAddr()
+	if err != nil {
+		return nil, err
+	}
 	if changedAddr != nil {
 		changedAddrHost := newHostFromStr(changedAddr.String())
 		resp.changedAddr = changedAddrHost
 	}
 	// compute otherAddr
-	otherAddr := pkt.getOtherAddr()
+	otherAddr, err := pkt.getOtherAddr()
+	if err != nil {
+		return nil, err
+	}
 	if otherAddr != nil {
 		otherAddrHost := newHostFromStr(otherAddr.String())
 		resp.otherAddr = otherAddrHost
 	}
 
-	return resp
+	return resp, nil
 }
 
 // String is only used for verbose mode output.

--- a/stun/tests.go
+++ b/stun/tests.go
@@ -32,7 +32,7 @@ func (c *Client) sendWithLog(conn net.PacketConn, addr *net.UDPAddr, changeIP bo
 	if resp != nil && !addrCompare(resp.serverAddr, addr, changeIP, changePort) {
 		return nil, errors.New("Server error: response IP/port")
 	}
-	return resp, err
+	return resp, nil
 }
 
 // Make sure IP and port  have or haven't change


### PR DESCRIPTION
This PR refactors the STUN client for safety, performance, and usability:

### Detailed Changes:
* **stun/attribute.go**: Added safety bounds checking to `rawAddr` and `xorAddr` to prevent runtime panics on truncated or malformed attributes.
* **stun/client.go**: Extracted connection setup logic into `acquireConn` to eliminate code duplication, and used `net.JoinHostPort` to fix IPv6 literal address resolution.
* **stun/log.go**: Redirected logger outputs to `os.Stderr` to prevent stdout pollution when using verbose mode.
* **stun/net.go**: Propagated packet parsing errors from `newResponse` to the send/receive loop.
* **stun/packet.go**: Decoupled parsed attributes from the temporary socket read buffer by copying parsed byte slices, and optimized packet serialization (`bytes()`) to pre-allocate the output buffer.
* **stun/response.go**: Updated `newResponse` to handle and propagate attribute decoding errors.
* **stun/tests.go**: Cleaned up the return values in `sendWithLog`.
* **stun/const.go**: Updated the default STUN server to `stun.sipgate.net:10000` since `stun.ekiga.net` has been retired.
* **Unit & Integration Tests**: Added a mock `net.PacketConn` and comprehensive tests to verify DiscoverNATType state machine and error handling logic.