### PR TITLE
Enable weekly Dependabot updates for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Add weekly Dependabot updates for Go modules
- Add weekly Dependabot updates for GitHub Actions

## Testing

- Not run (not requested)